### PR TITLE
[MANUAL MIRROR] renames Minor Breakage to Minor Skin Breakage

### DIFF
--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -156,7 +156,7 @@
 		try_treating(I, user)
 
 /datum/wound/pierce/moderate
-	name = "Minor Breakage"
+	name = "Minor Skin Breakage"
 	desc = "Patient's skin has been broken open, causing severe bruising and minor internal bleeding in affected area."
 	treat_text = "Treat affected site with bandaging or exposure to extreme cold. In dire cases, brief exposure to vacuum may suffice." // space is cold in ss13, so it's like an ice pack!
 	examine_desc = "has a small, circular hole, gently bleeding"


### PR DESCRIPTION
MANUAL MIRROR OF tgstation#77224 because bot bork

## About The Pull Request

This is a salt PR. I ded to bloodloss because in my head I read Minor Breakage as a broken bone and didn't notice i was bleeding.

## Why It's Good For The Game

I don't know if anyone else has this problem. This just sounds more readable because in hindsight I've tried to do shit like bonesetter minor breakages because I thought they were a broken bone.

## Changelog

:cl: zeroisthebiggay
spellcheck: Minor Breakage > Minor Skin Breakage for readability.
/:cl:
