### PR TITLE
[MANUAL MIRROR] Birdshot APC/Air Alarm pass

### DIFF
--- a/_maps/map_files/Birdshot/birdshot.dmm
+++ b/_maps/map_files/Birdshot/birdshot.dmm
@@ -594,6 +594,11 @@
 /obj/structure/railing/corner,
 /turf/open/space/basic,
 /area/space/nearstation)
+"alV" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/worn_out/directional/west,
+/turf/open/floor/iron,
+/area/station/maintenance/hallway/abandoned_recreation)
 "amp" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -2306,6 +2311,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
 /obj/machinery/camera/autoname/directional/west,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/checker,
 /area/station/security/breakroom)
 "aVZ" = (
@@ -2984,6 +2990,7 @@
 	},
 /obj/item/restraints/handcuffs,
 /obj/machinery/light/cold/directional/east,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs/auxiliary)
 "blh" = (
@@ -3220,6 +3227,8 @@
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
 /obj/machinery/light/small/directional/west,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
 "bpS" = (
@@ -4754,6 +4763,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"bUD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "bUE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -5192,6 +5210,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable,
 /turf/open/floor/iron/textured_half,
 /area/station/engineering/main)
 "cdf" = (
@@ -5485,6 +5504,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/small,
 /area/station/engineering/main)
 "clf" = (
@@ -5951,6 +5971,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "cuh" = (
@@ -5960,10 +5981,6 @@
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron,
 /area/station/security/prison/rec)
-"cuB" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "cuG" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -6998,6 +7015,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/small,
 /area/station/engineering/main)
 "cNF" = (
@@ -8200,6 +8219,15 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
+"dlc" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "dll" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan{
 	dir = 4
@@ -8844,6 +8872,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
 "dyW" = (
@@ -11027,6 +11056,8 @@
 /area/station/service/hydroponics)
 "enE" = (
 /obj/item/cultivator/rake,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
 "enG" = (
@@ -11450,6 +11481,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/navigate_destination/janitor,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "euO" = (
@@ -12966,6 +12998,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/random/directional/south,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "eVI" = (
@@ -13494,6 +13527,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/landmark/atmospheric_sanity/ignore_area,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
 "fiD" = (
@@ -16601,6 +16636,8 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname/directional/west,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "gkO" = (
@@ -18231,6 +18268,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
 "gPo" = (
@@ -19058,6 +19096,7 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/small,
 /area/station/science/xenobiology)
 "hcY" = (
@@ -20650,6 +20689,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/evidence)
 "hCQ" = (
@@ -22917,6 +22957,7 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/turf_decal/sand/plating,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/worn_out/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_command)
 "ius" = (
@@ -23106,6 +23147,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/security/detectives_office)
 "ixz" = (
@@ -25655,6 +25697,7 @@
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
 "jvP" = (
@@ -26591,6 +26634,7 @@
 	dir = 1
 	},
 /obj/machinery/light/cold/directional/south,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "jKq" = (
@@ -26865,6 +26909,7 @@
 "jOF" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light_switch/directional/west,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "jOK" = (
@@ -27040,6 +27085,7 @@
 	name = "Detective's Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/detective,
+/obj/structure/cable,
 /turf/open/floor/iron/textured_half,
 /area/station/security/detectives_office)
 "jTu" = (
@@ -28242,6 +28288,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"kqb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/iron/white/side,
+/area/station/science/research)
 "kqo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -29037,6 +29091,11 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
+"kEL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/prison)
 "kEO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/chaplain,
@@ -29552,6 +29611,7 @@
 "kNZ" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "kOc" = (
@@ -33705,6 +33765,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "mie" = (
@@ -34238,6 +34299,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/service/greenroom)
+"mtP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/dark_red/opposingcorners,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/iron,
+/area/station/security/prison)
 "mtV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34494,6 +34563,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "mya" = (
@@ -36228,6 +36298,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/hangover,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "nfG" = (
@@ -36245,6 +36316,7 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/sign/poster/official/random/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "nfS" = (
@@ -36259,6 +36331,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/departments/custodian/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ngo" = (
@@ -36270,6 +36343,7 @@
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ngq" = (
@@ -36300,6 +36374,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "ngL" = (
@@ -38079,6 +38154,7 @@
 /obj/machinery/door/airlock{
 	name = "Gardening Supplies"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/prison)
 "nNR" = (
@@ -40636,6 +40712,8 @@
 /obj/effect/turf_decal/tile/dark_red/anticorner/contrasted{
 	dir = 1
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
 "oND" = (
@@ -41066,6 +41144,7 @@
 	name = "Evidence Storage"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/security/evidence)
 "oUO" = (
@@ -41183,6 +41262,11 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
+"oXK" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/plating,
+/area/station/maintenance/department/bridge)
 "oXM" = (
 /obj/machinery/light/cold/directional/south,
 /obj/item/kirbyplants/random,
@@ -42415,6 +42499,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden/monastery)
 "pug" = (
@@ -43837,6 +43922,7 @@
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/decoration/statue,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
 "pRz" = (
@@ -44510,6 +44596,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/checker,
 /area/station/security/breakroom)
 "qbr" = (
@@ -45728,6 +45815,12 @@
 	dir = 8
 	},
 /area/station/service/theater)
+"quc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/commons/dorms)
 "quf" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -45987,6 +46080,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/security/detectives_office)
 "qyz" = (
@@ -48553,6 +48647,7 @@
 /area/station/security/brig)
 "rpq" = (
 /obj/machinery/camera/autoname/directional/east,
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/smooth,
 /area/station/security/evidence)
 "rpv" = (
@@ -49322,6 +49417,7 @@
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
 /obj/item/restraints/handcuffs,
 /obj/machinery/light/small/directional/west,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/customs)
 "rBx" = (
@@ -51530,6 +51626,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
 "slM" = (
@@ -54979,6 +55076,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security)
 "tuE" = (
@@ -58776,6 +58874,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/side,
 /area/station/science/research)
 "uGX" = (
@@ -62135,6 +62234,8 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname/directional/east,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/dark/small,
 /area/station/security/detectives_office)
 "vKX" = (
@@ -62810,6 +62911,7 @@
 /obj/machinery/light/cold/directional/south,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/security/checkpoint/escape)
 "vVw" = (
@@ -62990,6 +63092,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/small,
 /area/station/security/detectives_office)
 "vXs" = (
@@ -63220,6 +63323,7 @@
 /area/station/engineering/break_room)
 "wbk" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "wbp" = (
@@ -64743,6 +64847,7 @@
 /obj/structure/table/wood,
 /obj/item/hand_labeler,
 /obj/item/camera/detective,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "wAW" = (
@@ -66897,6 +67002,7 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 10
 	},
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "xgz" = (
@@ -67458,6 +67564,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/security/evidence)
 "xoB" = (
@@ -68198,6 +68306,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
 "xya" = (
@@ -81018,7 +81127,7 @@ bzs
 rQi
 bHW
 bUX
-cuB
+rQi
 cNy
 qLf
 qsi
@@ -85027,7 +85136,7 @@ cHR
 jZJ
 tDn
 wVI
-pGR
+kEL
 nNB
 wbk
 iWe
@@ -89910,7 +90019,7 @@ wbf
 wbf
 eTr
 wtr
-skn
+mtP
 hXY
 ihZ
 qxn
@@ -94678,7 +94787,7 @@ flM
 ifK
 izD
 izD
-uAY
+oXK
 izL
 uAY
 xRU
@@ -101647,7 +101756,7 @@ mIi
 vcN
 xpp
 xJB
-xvh
+bUD
 uPJ
 lek
 yhq
@@ -103685,7 +103794,7 @@ xVV
 dCH
 ixP
 sRL
-rsv
+quc
 mky
 rqw
 ohT
@@ -104711,7 +104820,7 @@ roB
 lde
 sRL
 lOH
-mhY
+dlc
 mxT
 ngw
 nAh
@@ -110102,7 +110211,7 @@ srW
 jAF
 jRN
 kba
-fxO
+alV
 kEo
 kMo
 leN
@@ -114756,7 +114865,7 @@ tdw
 uaV
 xfc
 vRh
-xUV
+kqb
 vbK
 xia
 xia


### PR DESCRIPTION
MANUAL MIRROR OF tgstation#77186

## About The Pull Request

I ran the "test areas" verb on Birdshot and added APCs to areas which were missing them, and air alarms to areas which were missing them.

## Why It's Good For The Game

People mentioned in the mapping channel that some places on Birdshot had infinite power, and I remember also people mentioning this in the past, but nobody made an issue report.

## Changelog

:cl:
fix: Several places on Birdshot which were missing an APC now aren't.
fix: Several places on Birdshot which were missing an air alarm now aren't.
/:cl:

